### PR TITLE
set mode = no-cors

### DIFF
--- a/sources/ikamand.js
+++ b/sources/ikamand.js
@@ -98,7 +98,7 @@ function fetchData(url, options)
 {
   options = {
     ...options,
-    //mode: "no-cors"
+    mode: "no-cors"
   };
   return fetch(url, options)
     .then(response =>


### PR DESCRIPTION
Set mode = no-cors on fetch request, fixes CORS error without plugin. Tested in Chrome 117

<img width="571" alt="image" src="https://github.com/ludekvodicka/ikamand/assets/752559/4d3af441-546a-4aee-811b-5cd88b35f210">


